### PR TITLE
[습관 생성 화면] 철자 틀려도 빨간 언더 라인 표시되지 않도록 수정하였습니다.

### DIFF
--- a/ONETHING_iOS/ONETHING_iOS/Source/View/DailyHabitView.swift
+++ b/ONETHING_iOS/ONETHING_iOS/Source/View/DailyHabitView.swift
@@ -50,6 +50,8 @@ final class DailyHabitView: UIView {
     }
     
     override func layoutSubviews() {
+        super.layoutSubviews()
+      
         self.layoutCloseButton()
         self.layoutTimeLabel()
         self.layoutDateLabel()

--- a/ONETHING_iOS/ONETHING_iOS/Source/View/HabitTextView.swift
+++ b/ONETHING_iOS/ONETHING_iOS/Source/View/HabitTextView.swift
@@ -27,6 +27,8 @@ final class HabitTextView: UITextView {
     }
     
     override func layoutSubviews() {
+        super.layoutSubviews()
+        
         self.layoutPlaceholderLabel()
         self.layoutBottomLines()
         self.layoutTextCountLabel()
@@ -37,6 +39,7 @@ final class HabitTextView: UITextView {
         self.layoutManager.delegate = self
         self.delegate = self
         self.isScrollEnabled = false
+        self.spellCheckingType = .no
     }
     
     private func setupPlaceholderLabel() {


### PR DESCRIPTION
> 스크린샷 

![빨간줄_숨김](https://user-images.githubusercontent.com/38216027/150129768-3da5743b-f465-41a2-a9eb-036cd69946c6.jpeg)

Closes #87 