### PR TITLE
[fix] 하단 탭바 iOS15 기준 분기쳐서 배경색 잘 나오도록 수정 및 shadow 값 적용하였습니다.

### DIFF
--- a/ONETHING_iOS/ONETHING_iOS.xcodeproj/project.pbxproj
+++ b/ONETHING_iOS/ONETHING_iOS.xcodeproj/project.pbxproj
@@ -551,6 +551,9 @@
 		F2BADE0626C5659400FD7766 /* WrappingHabitResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2BADE0526C5659400FD7766 /* WrappingHabitResponseModel.swift */; };
 		F2BADE0726C5659400FD7766 /* WrappingHabitResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2BADE0526C5659400FD7766 /* WrappingHabitResponseModel.swift */; };
 		F2BADE0826C5659400FD7766 /* WrappingHabitResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2BADE0526C5659400FD7766 /* WrappingHabitResponseModel.swift */; };
+		F2F10FA627AA5723006334AC /* CALayer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F10FA527AA5723006334AC /* CALayer+.swift */; };
+		F2F10FA727AA5723006334AC /* CALayer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F10FA527AA5723006334AC /* CALayer+.swift */; };
+		F2F10FA827AA5723006334AC /* CALayer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F10FA527AA5723006334AC /* CALayer+.swift */; };
 		F2F588A326B0042400F5430D /* PanGestureRecognizerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F588A226B0042400F5430D /* PanGestureRecognizerManager.swift */; };
 		F2F588A426B0042400F5430D /* PanGestureRecognizerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F588A226B0042400F5430D /* PanGestureRecognizerManager.swift */; };
 		F2F588A526B0042400F5430D /* PanGestureRecognizerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F588A226B0042400F5430D /* PanGestureRecognizerManager.swift */; };
@@ -787,6 +790,7 @@
 		F2B571ED26D4C6EF0059F75E /* WritingPenalty.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = WritingPenalty.storyboard; sourceTree = "<group>"; };
 		F2BADE0126C4E2D300FD7766 /* LargeTouchableButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeTouchableButton.swift; sourceTree = "<group>"; };
 		F2BADE0526C5659400FD7766 /* WrappingHabitResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrappingHabitResponseModel.swift; sourceTree = "<group>"; };
+		F2F10FA527AA5723006334AC /* CALayer+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+.swift"; sourceTree = "<group>"; };
 		F2F588A226B0042400F5430D /* PanGestureRecognizerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanGestureRecognizerManager.swift; sourceTree = "<group>"; };
 		F2F588AF26B0F95200F5430D /* LockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1153,6 +1157,7 @@
 				F27E217626BBA1B200020EE3 /* UICollectionViewDataSource+.swift */,
 				CE67520626D0F45500616CA8 /* UIButton+.swift */,
 				F25AE3712718630D009A59C6 /* UINavigationController+.swift */,
+				F2F10FA527AA5723006334AC /* CALayer+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1981,6 +1986,7 @@
 				F2BADE0226C4E2D300FD7766 /* LargeTouchableButton.swift in Sources */,
 				F23DD4CB26BEB3A600DCDDE5 /* DailyHabitViewModelable.swift in Sources */,
 				F2129BED26D7AD6E00C6D49E /* WritingPenaltyViewModel.swift in Sources */,
+				F2F10FA627AA5723006334AC /* CALayer+.swift in Sources */,
 				F25AE36A271835C1009A59C6 /* SuccessPopupViewModel.swift in Sources */,
 				F255719F26A432CE005A1AAF /* APIService.swift in Sources */,
 				F2A614B926A4254B0061A17A /* ContentAPI.swift in Sources */,
@@ -2145,6 +2151,7 @@
 				CE8FEDE626B6CBAD0092DC0D /* ProfileMenuTableViewCell.swift in Sources */,
 				F25571A926A43A55005A1AAF /* HabitInfoView.swift in Sources */,
 				F2017A8A26BBF982009277A6 /* SelectStampModel.swift in Sources */,
+				F2F10FA827AA5723006334AC /* CALayer+.swift in Sources */,
 				F25AE36C271835C1009A59C6 /* SuccessPopupViewModel.swift in Sources */,
 				F2129BEF26D7AD6E00C6D49E /* WritingPenaltyViewModel.swift in Sources */,
 				CED5AED426A49AD7003F087C /* GoalSettingFinishViewController.swift in Sources */,
@@ -2293,6 +2300,7 @@
 				F20E00E426A66172009A4AB3 /* HabitWritingViewModel.swift in Sources */,
 				CEFC3A2A269CA4620007AFF2 /* ObservableType+.swift in Sources */,
 				CED5AED326A49AD7003F087C /* GoalSettingFinishViewController.swift in Sources */,
+				F2F10FA727AA5723006334AC /* CALayer+.swift in Sources */,
 				F25AE36B271835C1009A59C6 /* SuccessPopupViewModel.swift in Sources */,
 				F2129BEE26D7AD6E00C6D49E /* WritingPenaltyViewModel.swift in Sources */,
 				CE8FEDD326B67F730092DC0D /* GoalSettingFinishViewModel.swift in Sources */,

--- a/ONETHING_iOS/ONETHING_iOS/Source/Extension/CALayer+.swift
+++ b/ONETHING_iOS/ONETHING_iOS/Source/Extension/CALayer+.swift
@@ -1,0 +1,33 @@
+//
+//  CALayer+.swift
+//  ONETHING_iOS
+//
+//  Created by sdean on 2022/02/02.
+//
+
+import UIKit
+
+extension CALayer {
+    func applyShadow(
+        color: UIColor = UIColor.black,
+        alpha: Float = 0.1,
+        x: CGFloat,
+        y: CGFloat,
+        blur: CGFloat,
+        spread: CGFloat = 0
+    ) {
+        self.masksToBounds = false
+        self.shadowColor = color.cgColor
+        self.shadowOpacity = alpha
+        self.shadowOffset = CGSize(width: x, height: y)
+        self.shadowRadius = blur / 2.0
+        
+        if spread == 0 {
+            self.shadowPath = nil
+        } else {
+            let dx = -spread
+            let rect = bounds.insetBy(dx: dx, dy: dx)
+            self.shadowPath = UIBezierPath(rect: rect).cgPath
+        }
+    }
+}

--- a/ONETHING_iOS/ONETHING_iOS/Source/ViewController/MainTabBarController.swift
+++ b/ONETHING_iOS/ONETHING_iOS/Source/ViewController/MainTabBarController.swift
@@ -12,8 +12,7 @@ final class MainTabBarController: UITabBarController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.tabBar.barTintColor = .white
-        self.tabBar.tintColor = .black_100
+        self.setupTabBar()
         self.setupViewControllers()
         self.setupUserInformIfNeeded()
         
@@ -63,6 +62,33 @@ final class MainTabBarController: UITabBarController {
             guard baseController.isViewLoaded == true                                  else { return }
             baseController.clearContents()
         }
+    }
+    
+    private func setupTabBar() {
+        if #available(iOS 15.0, *) {
+            self.setupTabBarBackgroundForiOS15Above()
+        } else {
+            self.setupTabBarBackgroundForiOS14Below()
+        }
+        
+        self.tabBar.layer.applyShadow(x: 0, y: 0, blur: 30.0)
+        self.tabBar.tintColor = .black_100
+    }
+    
+    private func setupTabBarBackgroundForiOS14Below() {
+        self.tabBar.barTintColor = .white
+        self.tabBar.isTranslucent = false
+        self.tabBar.backgroundImage = UIImage()
+        self.tabBar.shadowImage = UIImage()
+    }
+    
+    @available(iOS 15.0, *)
+    private func setupTabBarBackgroundForiOS15Above() {
+        let appearance = UITabBarAppearance()
+        appearance.configureWithTransparentBackground()
+        appearance.backgroundColor = .white
+        self.tabBar.standardAppearance = appearance
+        self.tabBar.scrollEdgeAppearance = appearance
     }
     
     private func setupViewControllers() {


### PR DESCRIPTION
### iOS15 이상에서도 TabBar 배경색 잘 나오도록 수정하였습니다.

* iOS15 의 이상의 경우 탭바나 네비게이션 바의 디폴트가 배경색이 투명색이라 이전에 배경색을 하얗게 적용했던것이 적용되지 않았는데 이를 코드 추가하여 다시 하얗게 나오도록 수정했습니다.

### 추가로 피그마에 나온대로 shadow 값 수정했습니다. 또 검은색 테두리를 지웠습니다.

* Figma의 Blur 30값이 적용되도록 코드 추가하였습니다. 

### iOS 15 미만, iOS 15 이상 모든 버전에 동일하게 나오도록 구현했습니다.

> iOS 14.3, iPhone8

<img width="561" alt="ios15미만" src="https://user-images.githubusercontent.com/38216027/152105091-59238475-78d7-45d5-a24b-6153a1c277ad.png">

> iOS 15.2, iPhone8

<img width="561" alt="iOS15이상" src="https://user-images.githubusercontent.com/38216027/152105153-69ed39ee-7868-44d6-99af-5b474caf5ffa.png">

Closes #96 