### PR TITLE
습관 누르면 크래시 나는 버그 해결 하였습니다. 

### DIFF
--- a/ONETHING_iOS/ONETHING_iOS.xcodeproj/xcshareddata/xcschemes/ONETHING Beta.xcscheme
+++ b/ONETHING_iOS/ONETHING_iOS.xcodeproj/xcshareddata/xcschemes/ONETHING Beta.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ONETHING_iOS/ONETHING_iOS.xcodeproj/xcshareddata/xcschemes/ONETHING Ent.xcscheme
+++ b/ONETHING_iOS/ONETHING_iOS.xcodeproj/xcshareddata/xcschemes/ONETHING Ent.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ONETHING_iOS/ONETHING_iOS.xcodeproj/xcshareddata/xcschemes/ONETHING.xcscheme
+++ b/ONETHING_iOS/ONETHING_iOS.xcodeproj/xcshareddata/xcschemes/ONETHING.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ONETHING_iOS/ONETHING_iOS/Source/Manager/SocialManager.swift
+++ b/ONETHING_iOS/ONETHING_iOS/Source/Manager/SocialManager.swift
@@ -20,7 +20,7 @@ final class SocialManager: NSObject {
     static let sharedInstance = SocialManager()
     
     func setup() {
-        KakaoSDKCommon.initSDK(appKey: SocialAccessType.kakao.appKey)
+        KakaoSDK.initSDK(appKey: SocialAccessType.kakao.appKey)
     }
     
     func handleSocialURLScheme(_ url: URL) {

--- a/ONETHING_iOS/ONETHING_iOS/Source/View/HabitTextView.swift
+++ b/ONETHING_iOS/ONETHING_iOS/Source/View/HabitTextView.swift
@@ -29,6 +29,11 @@ final class HabitTextView: UITextView {
     override func layoutSubviews() {
         super.layoutSubviews()
         
+        self.addSubview(self.placeholderLabel)
+        self.addSubview(self.firstBottomLine)
+        self.addSubview(self.secondBottomLine)
+        self.addSubview(self.textCountLabel)
+        
         self.layoutPlaceholderLabel()
         self.layoutBottomLines()
         self.layoutTextCountLabel()
@@ -49,14 +54,11 @@ final class HabitTextView: UITextView {
             $0.textColor = UIColor.init(hexString: "D7D7D7")
             $0.isHidden = false
         }
-        self.addSubview(self.placeholderLabel)
     }
     
     private func setupBottomLines() {
         self.firstBottomLine.backgroundColor = .black_10
         self.secondBottomLine.backgroundColor = .black_10
-        self.addSubview(self.firstBottomLine)
-        self.addSubview(self.secondBottomLine)
     }
     
     private func setupTextCountLabel() {
@@ -66,7 +68,6 @@ final class HabitTextView: UITextView {
             $0.textAlignment = .center
             $0.text = countText
         }
-        self.addSubview(self.textCountLabel)
     }
     
     private var countText: String {

--- a/ONETHING_iOS/Podfile
+++ b/ONETHING_iOS/Podfile
@@ -7,7 +7,7 @@ inhibit_all_warnings!
 abstract_target 'ONETHING_iOS' do
   use_frameworks!
 
-  pod 'KakaoSDKUser', '~> 2.5.4'
+  pod 'KakaoSDKUser', '~> 2.11.1'
   pod 'SnapKit', '~> 5.0.0'
   pod 'RxSwift', '~> 6.5.0'
   pod 'RxCocoa', '~> 6.5.0'

--- a/ONETHING_iOS/Podfile.lock
+++ b/ONETHING_iOS/Podfile.lock
@@ -2,17 +2,17 @@ PODS:
   - ActiveLabel (1.1.0)
   - Alamofire (5.4.4)
   - Carte (2.2.1)
-  - KakaoSDKAuth (2.5.6):
-    - KakaoSDKCommon (= 2.5.6)
-  - KakaoSDKCommon (2.5.6):
-    - KakaoSDKCommon/Common (= 2.5.6)
-    - KakaoSDKCommon/Network (= 2.5.6)
-  - KakaoSDKCommon/Common (2.5.6)
-  - KakaoSDKCommon/Network (2.5.6):
+  - KakaoSDKAuth (2.11.1):
+    - KakaoSDKCommon (= 2.11.1)
+  - KakaoSDKCommon (2.11.1):
+    - KakaoSDKCommon/Common (= 2.11.1)
+    - KakaoSDKCommon/Network (= 2.11.1)
+  - KakaoSDKCommon/Common (2.11.1)
+  - KakaoSDKCommon/Network (2.11.1):
     - Alamofire (~> 5.1)
-    - KakaoSDKCommon/Common (= 2.5.6)
-  - KakaoSDKUser (2.5.6):
-    - KakaoSDKAuth (= 2.5.6)
+    - KakaoSDKCommon/Common (= 2.11.1)
+  - KakaoSDKUser (2.11.1):
+    - KakaoSDKAuth (= 2.11.1)
   - Kingfisher (7.2.0)
   - lottie-ios (3.3.0)
   - Moya (14.0.0):
@@ -32,7 +32,7 @@ DEPENDENCIES:
   - ActiveLabel
   - Alamofire (~> 5.4.3)
   - Carte
-  - KakaoSDKUser (~> 2.5.4)
+  - KakaoSDKUser (~> 2.11.1)
   - Kingfisher (~> 7.0)
   - lottie-ios
   - Moya (~> 14.0)
@@ -62,9 +62,9 @@ SPEC CHECKSUMS:
   ActiveLabel: 5e3f4de79a1952d4604b845a0610d4776e4b82b3
   Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
   Carte: 6bcff4eaa894ff5b979d646de833fec96e04a38c
-  KakaoSDKAuth: 1e1fa737e78eed3f301ab5c164526781a37a42f9
-  KakaoSDKCommon: cdf340a8f671eef75f4ca012003cb350af3c4b6d
-  KakaoSDKUser: f488aa4699b3fd3a836ab5c7e25e2cb4cea190c1
+  KakaoSDKAuth: bb2dfa7be30daa8403c9cfc8001aa6fde7a5b779
+  KakaoSDKCommon: 555e1bb46595b842ded01cf7888cc17bbae4e113
+  KakaoSDKUser: 08c0a4f40bebdebdf948a9e3d0e44ed5c2754f99
   Kingfisher: 3ac0b75b155cabc0e544877d1a4deea29feece92
   lottie-ios: 6ac74dcc09904798f59b18cb3075c089d76be9ae
   Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
@@ -74,6 +74,6 @@ SPEC CHECKSUMS:
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
   Then: acfe0be7e98221c6204e12f8161459606d5d822d
 
-PODFILE CHECKSUM: 55cceca745cb820a39702a05f73555909515c941
+PODFILE CHECKSUM: 142d81dc70daf9d75a3ee4c727cc653aa5657b96
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3


### PR DESCRIPTION
* addsubview 를 init 말고 layoutsubviews에 위치하도록 해서 크래시 해결하였습니다.
  ~~* 이유: ios16부터 커스텀 뷰에서 init 보다 layoutsubviews 가 먼저 호출되어서 생긴 constraint nil runtime error 이슈입니다.~~
  * 이유 정정합니다. 당연히 해당 뷰의 init 이 먼저 불리지만 해당 init안에 setup() 안에 `self.layoutManager.delegate = self` 라는 코드가 layoutSubviews 메소드를 호출시켜버려  init안의 addSubview 메소드보다 layoutSubview안의 오토레이아웃 코드가 먼저 실행되어버려서 발생한 크래시 입니다.
* 추가로 xcode14 업데이트 하니 KaKaoSDK에 컴파일 에러 나서 SDK 버전 업데이트도 함께 하였습니다. 